### PR TITLE
#8 Log format is not correct

### DIFF
--- a/lib/resque/plugins/alarm_notifier/log_notifier.rb
+++ b/lib/resque/plugins/alarm_notifier/log_notifier.rb
@@ -14,7 +14,7 @@ module Resque
 
         private
         def format(params)
-          { app: @app_name, source: "resque-queue-length-alarm", type: "resque_queue_too_long", queues: params}
+          { app: @app_name, source: "resque-queue-length-alarm", type: "resque_queue_too_long", queues: params}.to_json
         end
       end
     end


### PR DESCRIPTION
#8: log should be a json string, so it can be parsed by another tool (ex: logstash)

@duongvanlong 2 concerns: 

1. This notifier is optional, and project could/should use its custom. Anw, I agree that string here is more general than hash. 
2. This will introduce 1 more dependencies: `json` which known is slow. Could we use string interpolation instead?
If went with `json` could you help to add it as development dependencies in Gemspec? 

Thanks. 